### PR TITLE
Configured ROS2 branch for vn100

### DIFF
--- a/vectornav/config/vectornav.yaml
+++ b/vectornav/config/vectornav.yaml
@@ -1,7 +1,9 @@
 vectornav:
   ros__parameters:
-    port: "/dev/ttyUSB0"
-    baud: 115200
+    # port: "/dev/ttyUSB0"
+    port: "/dev/serial/by-id/usb-FTDI_USB-RS232_Cable_AV0K7MTC-if00-port0"
+    # baud: 115200
+    baud: 921600
     reconnect_ms: 500
     # Reference vnproglib-1.2.0.0 headers for enum definitions
     # Async Output Type (ASCII)

--- a/vectornav/config/vn_100_800hz.yaml
+++ b/vectornav/config/vn_100_800hz.yaml
@@ -4,7 +4,8 @@
 
 vectornav:
   ros__parameters:
-    port: "/dev/ttyUSB0"
+    # port: "/dev/ttyUSB0"
+    port: "/dev/serial/by-id/usb-FTDI_USB-RS232_Cable_AV0K7MTC-if00-port0"
     baud: 921600
     adjust_ros_timestamp: True
     reconnect_ms: 500

--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -572,6 +572,8 @@ bool Vectornav::connect(const std::string port, const int baud)
   RCLCPP_INFO(get_logger(), "Serial Number : %d", sn);
   RCLCPP_INFO(get_logger(), "User Tag : \"%s\"", ut.c_str());
 
+  vs_->tare();
+
   return configure_sensor();
 }
 


### PR DESCRIPTION
Usage: 

Run with ros2 launch (Option 2, uses parameters from vectornav.yaml)

(Terminal 1) ros2 launch vectornav vectornav.launch.py
(Terminal 2) ros2 topic echo /vectornav/raw/common
(Terminal 3) ros2 topic echo /vectornav/imu

If issues, may need to run:

chmod 777 /dev/serial/by-id/usb-FTDI_USB-RS232_Cable_AV0K7MTC-if00-port0